### PR TITLE
Add URL routes for 0.44 docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,12 @@
 [[redirects]]
 from = "/version/stable/*"
-to = "https://pyvista-0-43.netlify.app/:splat"
+to = "https://pyvista-0-44.netlify.app/:splat"
+status = 200
+force = true
+
+[[redirects]]
+from = "/version/0.44/*"
+to = "https://pyvista-0-44.netlify.app/:splat"
 status = 200
 force = true
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,13143 +1,7497 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://docs.pyvista.org</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>1.0</priority>
+    <loc>https://docs.pyvista.org/version/stable/sg_execution_times.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/genindex</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/98-common/sg_execution_times</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/py-modindex.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/98-common/project-points-tessellate</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/404.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/98-common/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/genindex.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-kochanek-spline</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/search.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-pixel-art</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/user-guide/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/reader</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/user-guide/optional_features.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/read-image</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/user-guide/themes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-truss</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/user-guide/what-is-a-mesh.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/sg_execution_times</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/user-guide/data_model.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/read-dolfin</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/user-guide/simple.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-spline</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/user-guide/vtk_to_pyvista.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-surface-draped</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/user-guide/jupyter/trame.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-explicit-structured-grid</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/user-guide/jupyter/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-tri-surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/_static/webpack-macros.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-unstructured-surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/_static/static_viewer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/read-parallel</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/getting-started/why.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-pointset</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/getting-started/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-uniform-grid</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/getting-started/external_examples.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-structured-surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/getting-started/authors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-platonic-solids</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/getting-started/installation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/load-vrml</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/getting-started/connections.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-poly</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/sg_execution_times.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-geometric-objects</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/wrap-trimesh</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-polyhedron.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-polyhedron</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/sg_execution_times.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/linear-cells</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/wrap-trimesh.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-parametric-geometric-objects.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-parametric-geometric-objects</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/load-gltf</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-point-cloud.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-point-cloud</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-explicit-structured-grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/read-file</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-geometric-objects.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/create-polydata-strips</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/load-gltf.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/00-load/terrain-mesh</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-pixel-art.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/planets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/terrain-mesh.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/fea-hertzian-contact-pressure</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/reader.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/sphere_eversion</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-platonic-solids.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/sg_execution_times</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/read-file.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/plotting-algorithms</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/read-image.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/openfoam-cooling</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-tri-surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/antarctica-compare</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-truss.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/atomic-orbitals</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-uniform-grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/openfoam-tubes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/load-vrml.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/customization-trame-toolbar</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/linear-cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/osmnx-example</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-spline.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/magnetic-fields</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-structured-surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/add-example</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/read-dolfin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/extending-pyvista</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-polydata-strips.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/warp-by-vector-eigenmodes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-unstructured-surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/read-parallel.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/ray-trace</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-surface-draped.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/openfoam-example</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-kochanek-spline.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/pump-bracket</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-pointset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/99-advanced/ray-trace-moeller</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/00-load/create-poly.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/clip-volume</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/98-common/sg_execution_times.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/line-widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/98-common/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/animation</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/98-common/project-points-tessellate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/sg_execution_times</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/sg_execution_times.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/checkbox-widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/spline-widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/extending-pyvista.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/sphere-widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/warp-by-vector-eigenmodes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/box-widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/fea-hertzian-contact-pressure.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/plane-widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/sphere_eversion.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/slider-bar-widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/plotting-algorithms.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/multi-slider-widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/planets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/03-widgets/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/openfoam-example.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/mesh-quality</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/magnetic-fields.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/gradients</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/openfoam-cooling.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/surface-smoothing</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/atomic-orbitals.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/interpolate</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/ray-trace-moeller.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/integrate-data</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/pump-bracket.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/surface_reconstruction</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/ray-trace.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/contouring</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/openfoam-tubes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/voxelize</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/customization-trame-toolbar.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/compute-volume</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/antarctica-compare.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/rotate</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/99-advanced/add-example.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/gaussian-smoothing</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/04-lights/sg_execution_times.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/image-fft-perlin-noise</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/04-lights/beam_shape.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/boolean-operations</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/04-lights/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/sg_execution_times</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/04-lights/actors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/streamlines_2D</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/04-lights/attenuation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/slicing</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/04-lights/light_types.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/poly-ray-trace</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/04-lights/shadows.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/sampling_functions_3d</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/04-lights/mesh_lighting.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/subdivide</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/04-lights/plotter_builtins.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/resample</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/backface_props.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/extract-edges</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/legend.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/glyphs_table</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/shading.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/glyphs</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/chart_basics.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/connectivity</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/composite-picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/cell-centers</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/sg_execution_times.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/clipping</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/spherical.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/extract-surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/collisions</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/interpolate-before-map.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/sampling_functions_2d</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/floors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/distance-between-surfaces</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/depth-peeling.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/project-plane</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/clipping-with-surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/themes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/extract-cells-inside-surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/moving_cmap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/compute-normals</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/screenshot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/decimate</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/anti-aliasing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/flying_edges</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/topo-map.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/using-filters</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/vertices.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/reflect</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/vector-component.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/warp-by-vector</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/chart_overlays.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/extrude-rotate</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/movie_glyphs.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/geodesic</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/pbr.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/image-fft</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/blurring.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/streamlines</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/gif.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/ssao.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/01-filter/extrude-trim</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/depth_of_field.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/04-lights/beam_shape</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/distance_measurement.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/04-lights/sg_execution_times</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/plot-over-line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/04-lights/actors</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/04-lights/attenuation</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/ghost-cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/04-lights/plotter_builtins</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/multi-window.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/04-lights/mesh_lighting</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/cmap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/04-lights/light_types</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/point-picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/04-lights/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/edl.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/04-lights/shadows</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/element-picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/plot-over-circular-arc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/point-cell-scalars</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/clear.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/chart_basics</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/mesh-picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/silhouette</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/distance_measurement</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/point-cell-scalars.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/point-picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/distance-along-spline.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/anti-aliasing</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/silhouette.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/shading</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/linked.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/multi-window</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/scalar-bars.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/plot-over-circular-arc</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/isovalue.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/vertices</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/image_depth.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/backface_props</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/orbit.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/depth-peeling</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/lookup-table.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/background_image</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/sg_execution_times</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/volume.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/ssao</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/point-clouds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/point-clouds</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/movie.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/orbit</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/background_image.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/plot-over-line</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/points-gaussian-scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/composite-picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/color_cycler.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/depth_of_field</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/moving_cmap</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/ortho-slices.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/chart_overlays</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/lighting_mesh.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/movie</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/02-plot/surface-picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/lighting_mesh</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/reflect.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/element-picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/using-filters.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/edl</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/sg_execution_times.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/surface-picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/flying_edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/lookup-table</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/image-fft.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/linked</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/interpolate-before-map</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/subdivide.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/labels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/decimate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/opacity</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/extract-edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/scalar-bars</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/extract-cells-inside-surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/vector-component</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/streamlines.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/pbr</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/collisions.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/blurring</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/image-fft-perlin-noise.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/ortho-slices</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/distance-between-surfaces.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/themes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/extrude-rotate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/topo-map</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/cell-centers.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/volume</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/interpolate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/clipping-with-surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/cmap</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/gradients.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/bounds</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/surface_reconstruction.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/color_cycler</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/streamlines_2D.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/edges</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/image-representations.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/spherical</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/geodesic.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/ghost-cells</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/contouring.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/movie_glyphs</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/surface-smoothing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/floors</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/poly-ray-trace.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/mesh-picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/connectivity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/gif</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/rotate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/isovalue</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/extrude-trim.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/image_depth</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/glyphs.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/screenshot</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/integrate-data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/slicing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/clear</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/boolean-operations.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/examples/02-plot/distance-along-spline</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/mesh-quality.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/404</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/clipping.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/py-modindex</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/sampling_functions_2d.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/extras/pyinstaller</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/voxelize.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/extras/vtk_data</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/resample.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/extras/developer_notes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/extract-surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/extras/building_vtk</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/compute-volume.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/extras/pytest_plugin</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/project-plane.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/extras/extending_pyvista</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/sampling_functions_3d.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/extras/plot_directive</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/compute-normals.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/extras/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/warp-by-vector.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/extras/docker</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/gaussian-smoothing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/getting-started/connections</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/01-filter/glyphs_table.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/getting-started/authors</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/sg_execution_times.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/getting-started/why</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/getting-started/installation</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/box-widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/getting-started/external_examples</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/line-widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/getting-started/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/plane-widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_thermal_probes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/animation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/slider-bar-widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_chest</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/checkbox-widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_ivan_angel</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/clip-volume.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.file_from_files</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/spline-widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_teapot</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/multi-slider-widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_beach</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/examples/03-widgets/sphere-widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_spider</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_model_with_variance</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/typing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_puppy</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/dataset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_stars_sky_background</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/objects.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_sun</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_backward_facing_step</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/helpers.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_moonlanding_image</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/partitioned.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_quadratic_pyramid</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/grids.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_jupiter</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/filters.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_coil_magnetic_field</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/pointsets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_tetrahedron</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/lights.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_fea_bracket</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/composite.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bird_bath</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/misc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bunny_coarse</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_structured</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/camera.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_openfoam_tubes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_validation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_jupiter_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_oblique_cone</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.reverse.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.PentagonalPrism</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.validate_array3.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_filled_contours</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_office</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.triangulate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_sky_box_nz</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.point_data_to_cell_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_turbine_blade</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core.dataset.ActiveArrayInfo.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_carburetor</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.show_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_milkyway_sky_background</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.plot_normals.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_armadillo</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.translate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_lobster</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Quadrilateral</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.get_cell.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bolt_nut</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PartitionedDataSet.insert.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_mars</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.outline_corners.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_can</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.parallel_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_dicom_stack</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.clip.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_nefertiti</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_tensors_info.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_mercury</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.slice_along_line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_clown</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_feature_edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_blood_vessels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.validate_transform4x4.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.TriangleStrip</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.boolean_union.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Vertex</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.StructuredGrid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.number_of_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_notch_stress</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.array_names.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_pump_bracket</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.point_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Voxel</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGridFilters.clean.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_frog</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.obbTree.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_masonry_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.is_manifold.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_lidar</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.get_index_by_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_can_crushed_hdf</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.cells_to_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gears</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.StructuredGrid.points_matrix.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_tri_quadratic_hexahedron</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.compute_connectivity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_urn</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.azimuth.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_frog_tissue</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.point_data_to_cell_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cubemap_space_4k</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.thickness.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_knee_full</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.flip_y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_iron_protein</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.geodesic.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_topo_land</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.RectilinearGrid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_airplane</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.edge_mask.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_unstructured_grid</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.compute_boundary_mesh_quality.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_pluto_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_stars_cloud_hyg</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.cast_to_polydata.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_mount_damavand</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_neptune_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.multi_ray_trace.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gourds</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.select_enclosed_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.PolyLine</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.intersection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_naca</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.remove.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_globe_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.smooth.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_tetra_dc_mesh</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.compute_normals.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_face2</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.n_blocks.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_hydrogen_orbital</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cow</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.plot_over_circular_arc_normal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cavity</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.find_closest_cell.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cake_easy</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_dragon</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.clip_box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_letter_k</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.outline.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_fea_hertzian_contact_cylinder</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.cast_to_structured_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.delete_downloads</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_texture_coordinates.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_trumpet</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.point_normals.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_brain</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGridFilters.reconstruct_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gpr_path</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.clear_point_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.demos.demos.plot_beam</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_scalars.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_saturn_rings</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.insert.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_knee</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.wrap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_shark</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.cell_neighbors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Empty</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.focal_point.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_electronics_cooling</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.cast_to_poly_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_woman</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.shallow_copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_tetbeam</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.memory_address.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_guitar</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_channels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.n_strips.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_exodus</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.project_points_to_plane.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bird</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.switch_off.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_faults</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_shape.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_neptune</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.distance.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cad_model</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_t_coords_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_pepper</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.find_cells_within_bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_venus</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.decimate_boundary.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_dual_sphere_animation</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.contour_labeled.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_rectilinear_grid</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.enable_parallel_projection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_meshio_xdmf</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.cell_data_to_point_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_plastic_vase</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.extract_geometry.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_black_vase</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.remove_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_human</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.contour.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_room_surface_mesh</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.elevation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_sphere</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.row_arrays.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_random_hills</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.slice_orthogonal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cow_head</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.plot_cell</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.RectilinearGrid.cast_to_structured_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_louis_louvre</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.cell_id.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_owl</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.slice.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_motor</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.cell_centers.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_crater_topo</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cloud_dark_matter_dense</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.validate_data_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_topo_global</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.subdivide.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_puppy_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.compute_derivative.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bunny</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.point_ids.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gourds_pnm</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.boolean_intersection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Line</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.clip_box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_uniform</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.extract_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_mug</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.save.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gpr_data_array</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_scalars.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_mars_jpg</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.clear_all_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_particles_lethe</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.hide_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Pyramid</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.view_frustum.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_coastlines</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.zoom.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_hexbeam</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.intensity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gourds_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.is_headlight.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_vtk_logo</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_real.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cloud_dark_matter</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.verts.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_torso</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.get_face.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.demos.demos.orientation_plotter</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.fill_holes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_st_helens</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.cell_data_to_point_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_vtk</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.transform.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_pluto</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.cell_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_logo</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.flip_x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_single_sphere_animation</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.replace.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_brain_atlas_with_sides</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.volume.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_antarctica_velocity</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.mipmap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_tensors</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.curvature.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cubemap_park</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.area.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_crater_imagery</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.connectivity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.demos.demos</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.is_all_polydata.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_earth</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.clear_all_point_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_sky_box_cube_map</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.regular_faces.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_saturn_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.shallow_copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_lucy</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_nonnegative.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cells_nd</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.split_values.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cubemap_space_16k</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.n_faces_strict.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_uranus</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.n_rows.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_mercury_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.rotate_z.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_horse_points</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.type.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_damavand_volcano</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.reconstruct_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_spline</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.copy_meta_from.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.demos.demos.plot_wave</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.n_open_edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_usa</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_greater_than.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_globe</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_texture_coordinates_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_angular_sector</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.get_data_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_notch_displacement</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_embryo</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.faces.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_sun_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_kitchen</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.world_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cake_easy_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_normals_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_rectilinear</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.compute_cell_quality.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_doorman</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.texture_map_to_sphere.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_wavy</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.demos.demos.plot_glyphs</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PartitionedDataSet.append.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_poly_line</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.n_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_action_figure</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.slice_along_line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cgns_multi</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.items.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bird_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_prostate</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.streamlines_evenly_spaced_2D.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_pine_roots</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.pop.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_saturn</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.dimensions.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_delaunay_example</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.StructuredGrid.z.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Hexahedron</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.sample.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Tetrahedron</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.point_is_inside_cell.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Triangle</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.get.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.PolyVertex</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.StructuredGrid.hide_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_osmnx_graph</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.to_paraview_pvcc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cgns_structured</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.demos.demos.plot_ants_plane</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.set_block_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.demos.demos.plot_datasets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.shrink.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_nut</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.copy_structure.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_venus_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGridFilters.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_face</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.plot_curvature.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cylinder_crossflow</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.point_data_to_cell_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_rgba_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.glyph.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_saddle_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.RectilinearGrid.y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_drill</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.volume.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_dolfin</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.integrate_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.n_verts.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_ant</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.cast_to_unstructured_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_usa_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.to_image.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_sea_vase</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.validate_arrayN.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_emoji_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.find_cells_intersecting_line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_head</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.explode.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_blow</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.values.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_aero_bracket</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.decimate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cad_model_case</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGrid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_file</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.gaussian_smooth.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_dikhololo_night</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.remove_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_explicit_structured</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.separate_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_parched_canal_4k</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.find_containing_cell.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_letter_a</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.set_active_tensors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_head_2</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_integer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.examples.load_sphere_vectors</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.find_cells_along_line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Polygon</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PartitionedDataSet.copy_meta_from.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.load_moon</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.flip_y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_horse</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PartitionedDataSet.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_uranus_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.get_array_association.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.HexagonalPrism</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.diffuse_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_stars_jpg</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.outline_corners.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_tecplot_ascii</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.to_pandas.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_sky_box_nz_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_instance.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_structured_grid_two</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_vectors_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.demos.demos.orientation_cube</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_carotid</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.shadow_attenuation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_disc_quads</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.extent.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_emoji</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.set_headlight.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.cells.Wedge</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.merge.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_foot_bones</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.sort_labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_moon_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.low_pass.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gif_simple</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.faces.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_mars_surface</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.clear_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.planets.download_saturn_rings</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.parallel_projection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_sparse_points</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.append.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.demos.demos.glyphs</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.point_cell_ids.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_structured_grid</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.sample_over_circular_arc_normal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/_autosummary/pyvista.examples.downloads.download_honolulu</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.n_faces.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/examples/index</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_legend_scale</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_vectors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.auto_close</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.RectilinearGrid.meshgrid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_label_format</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.is_set.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_actor</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.compute_arc_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.get_image_depth</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.light_type.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_path_picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.extract_all_edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_depth_of_field</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.world_focal_point.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.slider_styles</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.add_renderer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.mouse_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.sample_over_circular_arc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.increment_point_size_and_line_width</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.extract_geometry.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.set_color_cycler</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.warp_by_scalar.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.depth_peeling</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.slice_orthogonal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.justification_horizontal</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.ambient_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.show_frame</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_environment_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.cast_to_unstructured_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_event_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.specular_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.get_default_cam_pos</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.extrude_trim.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_clip_box</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.slice_implicit.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.picked_cells</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.high_pass.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.specular_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.get_pick_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.cell_normals.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.n_values</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.clip_scalar.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.deep_clean</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.rename_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.save_graphic</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Text.input</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.threshold.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.reset_picker</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGrid.offset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_3_lights</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.flip_x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.to_opacity_tf</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.clear_key_event_callbacks</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.clip_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Axes.hide_symmetric</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_subdtype.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Axes.show_symmetric</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.save.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.slider_width</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.set_camera_light.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.show_edges</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.compute_cell_sizes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_vectors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.bounds</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.decimate_pro.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_shadows</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.cell_data_to_point_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.cone_resolution</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.RectilinearGrid.dimensions.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.update_bounds_axes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.warp_by_vector.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_slice_orthogonal</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.dataset</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.copy_meta_from.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.floor_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.dimension.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.store_click_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.RectilinearGrid.x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.cube_map.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_slider_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.protein_ribbon.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.create_axes_marker</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGrid.cells_dict.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.title</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_number.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.sphere_resolution</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.to_tetrahedra.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.specular_power</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.get_data_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_axis_visibility</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.ctp.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CameraPosition.viewup</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.delaunay_3d.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.nan_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.clipping_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor.pickable</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.track_click_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.threshold_percent.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_box_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.slice_along_axis.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.key_press_event</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.visible_bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_blurring</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.is_all_triangles.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.cylinder_radius</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.model_transform_matrix.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.opts.InterpolationType</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_vectors_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.store_mouse_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.neighbors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_camera_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.y_axis_shaft_properties</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.extrude_rotate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.write_frame</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_scalars_info.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.cylinder_resolution</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.tight.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_legend</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PartitionedDataSet.pop.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_sphere_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_t_coords.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.slider_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.cast_to_polydata.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.next_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.validate_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_title</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.from_regular_faces.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_ssao</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.interpolate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_trackball_style</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.add_field_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_logo_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.is_linear.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.fly_to_mouse_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.roll.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Timer</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_plane_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.pop.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_lightkit</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.explode.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.track_mouse_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.flip_normal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.return_cpos</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.irregular_faces.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.silhouette</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_scalars_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_slice</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.point_neighbors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_rectangle_through_picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.show_actor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.picked_actor</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.geodesic_distance.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.save</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.reset_clipping_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.scalar_bars</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.transform_matrix.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_actors</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.n_columns.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_box_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.merge.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_finite.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.lighting_params</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.up.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._ColorbarConfig.height</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.rotate_cw.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.logo_file</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.n_edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.disable_hidden_line_removal</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.view_angle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.saturation_range</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.StructuredGrid.x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.annotations</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_type.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.metallic</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.StructuredGrid.dimensions.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_hidden_line_removal</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_normals.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Text.position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_vectors_info.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CameraPosition.position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.delaunay_3d.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.clear</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.strips.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.block_attr</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.validate_number.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Prop3D.bounds</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PartitionedDataSet.n_partitions.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.disable_parallel_projection</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.values.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.color_cycler</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.log_scale</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_string.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.label_size</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.extrude.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.disable_shadows</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.clean.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.window_size</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.decimate_boundary.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.untrack_click_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.find_closest_point.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.DataSetMapper</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.compute_connections.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.BlockAttributes.pickable</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.smooth_taubin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.last_update_time</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_cursor</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.wrap_nested.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.isometric_view</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.attenuation_values.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_label_visibility</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.extend.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_scalar_bar</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core.utilities.arrays.FieldAssociation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.ambient</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.cell.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.set_focus</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.lines.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_trackball_actor_style</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.median_smooth.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_measurement_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.ribbon.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.export_html</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.point_is_inside_cell.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_axis_minor_tick_visibility</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.append_polydata.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._DepthPeelingConfig.number_of_peels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.validate_arrayN_unsigned.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_border</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.collision.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_event_subplot_loc</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_iterable_items.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.line_width</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_slider_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.hide_axes_all</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.compute_implicit_distance.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.split_sharp_edges</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_largest.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.subplot</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_all_edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.interactive_ratio</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.cast_to_pointset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.strip.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.remove_floors</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.streamlines.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_rubber_band_2d_style</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.get.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_image_style</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.parallel_scale</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.boolean_difference.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.export_gltf</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.set_vectors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor.visibility</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.from_irregular_faces.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_blurring</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.number_of_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.enable_parallel_projection</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_axis_minor_tick_visibility</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_spline_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.clip.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Text.prop</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_trackball_style</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.hide_axes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.window_size_context</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.n_faces.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_chart</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.use_strict_n_faces.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.clear_field_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.multi_samples</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.get.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.n_xlabels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PartitionedDataSet.wrap_nested.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.enable_camera_orientation_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_logo_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.keys.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.enable_eye_dome_lighting</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.as_polydata_blocks.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_zoom_style</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.set_scene_light.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_measure_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.flip_z.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._ColorbarConfig</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.show</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.validate_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.camera</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.outline.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.below_range_opacity</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.clean.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.name</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.validate_transform3x3.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_spline_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core.utilities.features.perlin_noise.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.diffuse</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.RectilinearGrid.points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.below_range_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.hide_actor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_text</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.pop.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.view_zy</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.set_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.use_2d_mode</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.slice_along_axis.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.where_is</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.plot_boundaries.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.clear_events_for_key</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.copy_from.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.show_bounds</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_scalars_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.y_axis_tip_properties</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.switch_on.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.image_depth</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.enable_anti_aliasing</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.triangulate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.above_range_opacity</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.on.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_camera_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.is_scene_light.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Prop3D.orientation</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.set_active_scalars.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.export_obj</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.ambient</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.to_grayscale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.scalar_range</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.shrink.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.colorbar_vertical</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.copy</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.rotate_vector.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.picked_cell</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.reset_colors</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.cap_length</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGrid.linear_copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.plot</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.StructuredGrid.y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_parallel_projection</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.volume.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_isovalue</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.get_edge.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.show_grid</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.dimensions.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.export_vtksz</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.flip_normals.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.opts.ElementType</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.from_paraview_pvcc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_point_scalar_labels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.slice.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.poked_subplot</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PartitionedDataSet.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.font_size</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.origin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.opacity</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.partition.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.set_environment_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.renderers.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.name</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.ray_trace.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CameraPosition.to_list</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.RectilinearGrid.z.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.render</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.slice_orthogonal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_logo_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.enable_depth_of_field</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_geometry.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.full_screen</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_normals.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.points_to_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_bounding_box</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.field_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.initialize</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.camera_set</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGridFilters.subdivide_tetra.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.enable_depth_peeling</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGrid.cast_to_explicit_structured_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.trame</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.direction.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.close</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.repeat.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.camera_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.cast_to_rectilinear_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.border_width</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.interpolate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_slice_spline</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.cell_coords.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_spline_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.elevation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.actors</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.n_components.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.pick_click_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.threshold_percent.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Prop3D.rotate_z</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.positional.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_composite</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.tessellate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_anti_aliasing</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.validate.validate_arrayNx3.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.remove_environment_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_values.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.reset_key_events</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.plot_over_circular_arc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.value_range</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.cast_to_unstructured_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.tick_location</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.valid_array_len.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_line_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.rotate_y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.set_focus</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.actual_memory_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.picker</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.view_vector</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_texture_coordinates.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor.prop</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.disable_parallel_projection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.show_grid</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.extract_subset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_button_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.plot_over_line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.still_ratio</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_cells_by_type.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.border_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.user_dict.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_floors</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.triangulate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.fly_to</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.save.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_silhouette</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.pack_labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.background</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_camera_orientation_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.separate_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_depth_peeling</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.get_block_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.start</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.point_neighbors_levels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.rebuild</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.focal_point.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.import_vrml</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_iterable.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.viewport</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._DepthPeelingConfig.enabled</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.pad_image.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.set_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.get_data_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.cmap</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.items.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.opts.RepresentationType</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.n_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.colorbar_orientation</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.deep_copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_volume_clip_plane</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.tube_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.find_cells_along_line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_joystick_style</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.keys.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.BlockAttributes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.triangulate_contours.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.DarkTheme</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.subdivide_adaptive.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.initialized</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.reflect.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.left_button_down</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.from_vtk.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_actor</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.copy_meta_from.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_checkbox_button_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core.dataset.ActiveArrayInfo.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.frame_width</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.arrows.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_slider_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.slice_along_line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.camera</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.save.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.view_vector</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_cell_picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.set_active_scalars.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.bounds</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.set_scalars.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CornerAnnotation</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.n_arrays.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.DataSetMapper.dataset</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CornerAnnotation.linear_font_scale_factor</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.image_dilate_erode.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.family</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.cell_centers.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.deep_clean</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.clear.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.set_chart_interaction</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.sample_over_multiple_lines.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_clip_plane</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.cast_to_unstructured_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.specular_power</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.clip_closed_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_legend</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGrid.cell_connectivity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_picker</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_t_coords.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.fft.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.array_name</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.tessellate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.export_vrml</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.StructuredGrid.hide_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.reset_camera_clipping_range</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.to_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.remove_chart</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.exponent.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_arrows</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.clear_all_cell_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.cmap</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.ptc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.view_yx</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.is_camera_light.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_rubber_band_2d_style</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.keys.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.lighting</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_sorted.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.contour_banded.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.disable</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.MultiBlock.volume.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_anti_aliasing</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGrid.celltypes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderConfig.classic</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.combine.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.apply_lookup_table</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.face_normals.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_plane_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.cone_angle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_axes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.BlockAttributes.opacity</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.image_threshold.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_light</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.align.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Timer.execute</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Camera.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.fly_to</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.threshold.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.interpolate_before_map</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Light.set_direction_angle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.server_proxy_prefix</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.n_arrays.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.reset_camera_clipping_range</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.streamlines_from_source.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.justification_vertical</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.copy_attributes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.label_offset</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGrid.cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.edge_opacity</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.to_skybox.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.background_opacity</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.slice_along_axis.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_point_picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._ColorbarConfig.position_x</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.CompositeFilters.compute_cell_sizes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_slice_orthogonal</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_sequence.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.render_window</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetAttributes.get_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.specular</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.delaunay_2d.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.DataSetMapper.cmap</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataObject.head.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.reset_opacities</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.elevation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.update_scalar_bar_range</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.slice.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_title</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.area.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.x_axis_tip_properties</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.z.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.sample_over_line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.independent_components</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageDataFilters.rfft.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.DocumentTheme</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.ImageData.spacing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_label_visibility</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyData.n_lines.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_axis_range</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.contour.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.interpolation</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.UnstructuredGridFilters.delaunay_2d.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.view_yz</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.split_bodies.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.above_range_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.cell_neighbors_levels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_labels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.set_active_vectors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.edge_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.rotate_x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.interpolate_before_map</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.clear_cell_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderConfig</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.texture_map_to_plane.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Cell.n_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.notebook</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_contains.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.show_edges</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PolyDataFilters.tube.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_axis_minor_tick_visibility</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Table.get_data_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_slice_spline</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core.utilities.features.sample_function.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_light</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.surface_indices.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.show_axes_all</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.PointSet.triangulate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_block_picking</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.get_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_events_for_key</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.Texture.rotate_ccw.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_ssao</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.core._validation.check.check_less_than.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.remove_observer</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.slice_implicit.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.interactive</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_tensors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.DataSetMapper.set_scalars</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSet.active_tensors_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.disable_depth_peeling</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.DataSetFilters.sample.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.set_environment_texture</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/colors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_point_labels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/image.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.show_scalar_bar</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_labels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/utilities.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.before_close_callback</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/parametric.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.key_press_event</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/geometric.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.ParaViewTheme</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/color_table/color_table.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor.memory_address</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageMandelbrotSource.maxiter.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.set_plot_theme</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.start_xvfb.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.enable_shadows</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.float_rgba.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_axis_visibility</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ArrowSource.tip_radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_ruler</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageNoiseSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.update_bounds</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricCrossCap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.remove</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3DSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.jupyter_extension_enabled</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGaussianSource.std.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.n_ylabels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricCatalanMinimal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.width</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CubeSource.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.alpha_range</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.float_rgb.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_plane_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ArrowSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.scale</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.scalar_bar</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.core.utilities.axis_rotation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Prop3D.center</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Polygon.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.n_zlabels</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CubeSource.point_dtype.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.picked_mesh</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGridSource.origin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.background_color</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.shaft_type.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.interpolation</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricBour.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor.backface_prop</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.convert_color_channel.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.colorbar_horizontal</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ArrowSource.tip_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.style</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CylinderSource.height.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricKuen.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.bounds</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.vtk_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.set_chart_interaction</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Pyramid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.cone_radius</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CellType.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume.Volume.prop</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PlatonicSolid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_orientation_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3DSource.depth.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.render_lines_as_tubes</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.LineSource.pointa.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_measure_widgets</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3DSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.track_mouse_position</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ArrowSource.shaft_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.remove_bounding_box</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3DSource.process_empty_string.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor.mapper</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CylinderSource.resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.origin</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.compare_images.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.wrap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_axes_at_origin</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.to_dict.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_ruler</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.hex_rgb.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.total_length</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SphereSource.radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_joystick_actor_style</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricConicSpiral.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_orientation_widget</loc>
-    <lastmod>2023-12-07T11:44:11+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CylinderSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PlaneSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_parallel_projection</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PlatonicSolidSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.hue_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGridSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.z_axis_tip_properties</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.vtk_c3ub.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.set_scale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SphereSource.start_theta.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_eye_dome_lighting</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.disable_eye_dome_lighting</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.theta_roundness.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_bounding_box</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.image_to_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.destroy_timer</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ConeSource.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricSuperToroid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Axes.origin</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricDini.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_eye_dome_lighting</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.LineSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.x_axis_shaft_properties</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageSinusoidSource.period.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_timer_event</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Spline.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.interpolation_type</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CubeSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.visibility</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricRandomHills.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._DepthPeelingConfig.occlusion_ratio</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ConeSource.angle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_axis_visibility</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ConeSource.resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PolygonSource.normal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.reset_camera</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CubeSource.y_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.isometric_view</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PlaneSource.i_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.legend</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.get_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3DSource.height.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageNoiseSource.whole_extent.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.view_isometric</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageEllipsoidSource.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.reset_visibilities</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Triangle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.title_size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.DiscSource.r_res.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.render_lines_as_tubes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.get_block</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.merge.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.apply_opacity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricMobius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_surface_point_picking</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PlatonicSolidSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_stereo_render</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Octahedron.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor.texture</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageSinusoidSource.direction.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.image_scale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.int_rgba.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_box_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.vtkmatrix_from_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.camera_set</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageEllipsoidSource.radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.update_coordinates</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CubeSource.z_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.tube_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CylinderSource.capping.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CornerAnnotation.get_text</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.field_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.ambient</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.save_meshio.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CubeSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.enable_shadow</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PolygonSource.fill.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.color_missing_with_nan</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.array_from_vtkmatrix.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.server_proxy_enabled</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.spherical_to_cartesian.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_measurement_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CylinderSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.BlockAttributes.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SphereSource.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.import_gltf</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.point_size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageSinusoidSource.amplitude.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.image_scale_context</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.symmetric_bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.create_axes_orientation_box</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.set_background</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricRoman.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CornerAnnotation.prop</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.create_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.edge_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.is_pyvista_dataset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_scalar_bar</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.phi_roundness.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_slice</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PolygonSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.update_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ConeSource.radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_rectangle_visible_picking</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.perlin_noise.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Prop3D.rotate_y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.MultipleLines.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.enable</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.sample_function.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_threshold</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.DiscSource.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.meshes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SphereSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.add_observer</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.MultipleLinesSource.points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_key_event</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Capsule.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.nan_opacity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageMandelbrotSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositeAttributes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.hex_rgba.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume.Volume.mapper</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageNoiseSource.seed.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_volume_clip_plane</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGaussianSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.add_pick_obeserver</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageSinusoidSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.convert_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.lighting</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3DSource.normal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.shape</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Cone.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.has_charts</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.BoxSource.quads.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.track_click_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.theta_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.enable_geodesic_picking</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.DiscSource.outer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.enable_horizon_picking</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageSinusoidSource.whole_extent.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_title</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Dodecahedron.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_chart</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SphereSource.end_phi.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.scalar_visibility</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.read.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.show_vertices</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.KochanekSpline.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_axis_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SphereSource.end_theta.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_bounds_axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGridSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.view_zx</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.phi_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.scalar_map_mode</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.toroidal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_labels</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CircularArcFromNormal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.jupyter_server_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGaussianSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_element_picking</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ArrowSource.tip_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.render_points_as_spheres</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.BoxSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.fmt</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.symmetric.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.restore_defaults</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.point_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.untrack_mouse_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.MultipleLinesSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_affine_transform_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.LineSource.resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CameraPosition</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.grid_from_sph_coords.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.view_yx</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageNoiseSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3DSource.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageMandelbrotSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.enable_path_picking</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CylinderStructured.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.window_size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CylinderSource.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.above_range_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_blurring</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.strip_hex_prefix.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_axis_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3D.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_line_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.tip_radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.shaft_length</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.layer</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ColorLike.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_legend_scale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CubeSource.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.center</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.pyvista_ndarray.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.close</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.read_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_line_widgets</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.fit_plane_to_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.set_color_cycler</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Arrow.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.set_font_file</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_affine_transform_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PolygonSource.radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.set_viewup</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ConeSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_poked_renderer</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CubeSource.x_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.link_views</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.cartesian_to_spherical.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.isometric_view_interactive</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Sphere.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_box_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Icosahedron.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.renderer</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageSinusoidSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.set_scalars</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.BoxSource.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PlaneSource.j_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.picked_point</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.voxelize.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_3_lights</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.cubemap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PlatonicSolidSource.kind.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_interactor_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.DiscSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.reset_camera</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ConeSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.title_offset</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SphereSource.theta_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.emissive</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.tip_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.camera</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageEllipsoidSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_image_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3DSource.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_hidden_line_removal</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.BoxSource.level.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume.Volume</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Wavelet.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.hidden_line_removal</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricFigure8Klein.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.length</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Rectangle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.remove_blurring</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageNoiseSource.maximum.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_background_image</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ArrowSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.bounds</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.LineSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.lights</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Superquadric.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._ColorbarConfig.width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricPseudosphere.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.tip_type</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Circle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.y_axis_label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.srgb_to_linear.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.get_default_cam_pos</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Cube.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.clear_actors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PolygonSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_joystick_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.from_dict.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.enabled</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ArrowSource.shaft_radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.transparent_background</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.numpy_to_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.close</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3DSource.width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_all_lights</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.MultipleLinesSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_sphere_widgets</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SolidSphereGeneric.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_text_slider_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.cubemap_from_filenames.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_button_widgets</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CircularArc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.outline_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricBohemianDome.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.update_bounds_axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.DiscSource.inner.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.close</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.transform_vectors_sph_to_cart.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_isovalue</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ConeSource.height.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.background_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricSuperEllipsoid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.set_render_window</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.BoxSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.view_xy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGaussianSource.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.remove_observers</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.core.utilities.is_inside_bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.default_mode</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.parametric_keywords.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.shade</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SolidSphere.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_clip_plane</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.DiscSource.c_res.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.pickable_actors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.shaft_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.image_scale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plot_arrows</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.int_rgb.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.disable_ssao</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageEllipsoidSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.sphere_radius</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Tube.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.culling</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageMandelbrotSource.whole_extent.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.view_isometric</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricTorus.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.to_color_tf</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageNoiseSource.minimum.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.cell_array.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_background_image</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.surface_from_para.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.remove_all_lights</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.linear_to_srgb.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.core.utilities.set_error_output_file.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.theme</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SuperquadricSource.thickness.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.click_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PolygonSource.n_sides.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CornerAnnotation.set_text</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricBoy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.color_mode</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Text3DSource.string.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_line_widgets</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Disc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CylinderSource.capsule_cap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.show_axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.lines_from_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.set_unique_colors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.shaft_radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.set_background</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGridSource.spacing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.core.utilities.VtkErrorCatcher.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.open_movie</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.AxesGeometrySource.tip_type.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.length</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SphereSource.start_phi.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._ColorbarConfig.position_y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Icosphere.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_joystick_actor_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricPluckerConoid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.decimate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Tetrahedron.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_desired_update_rate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.voxelize_volume.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._DepthPeelingConfig</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricEnneper.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.lookup_table</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SphereSource.phi_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.line_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricHenneberg.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_actor</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.on_plotter_render</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.LineSource.pointb.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Cylinder.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.anti_aliasing</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricEllipsoid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.disable_anti_aliasing</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGridSource.extent.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.jupyter_server_port</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ConeSource.direction.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.pick_mouse_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Report.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_horizon_picking</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.read_exodus.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_title</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PlaneSource.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.picked_block_index</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageEllipsoidSource.whole_extent.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ConeSource.capping.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_floor</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Color.name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Prop3D</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.SphereSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.edge_opacity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ParametricKlein.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.feature_angle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CylinderSource.radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.view_yz</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.DiscSource.output.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.load_theme</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.Plane.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_stereo_render</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGaussianSource.whole_extent.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.x_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.PolygonSource.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.zoom_camera</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageSinusoidSource.phase.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.opacity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.ImageGaussianSource.maximum.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_slider_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.CylinderSource.direction.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.opacity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/utilities/_autosummary/pyvista.vector_poly_data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.cap_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/trame.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.screenshot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/qt_plotting.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.untrack_click_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/conv_func.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.opacity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/plotting.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_threshold</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/theme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.jupyter_backend</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/scatter_marker_styles.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.BlockAttributes.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.hide_axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/pen_line_styles.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_fly_to_right_click</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/plot_color_schemes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.font_family</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.border_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_shadows</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_label_format</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.parallel_scale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.background_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_rectangle_picking</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.border_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.enable</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.pen.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Text</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.active_border_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_rubber_band_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_labels_visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_depth_of_field</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.volume_mapper</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.margin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.show</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.pen.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.orbit_on_path</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.marker_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.DataSetMapper.as_rgba</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.colors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.diffuse_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.figure.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_sphere_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.shaft_type</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.active_border_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_trackball_actor_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.actors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.stats.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.unlink_views</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.enable_fly_to_right_click</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_label_visibility</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.title.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_geodesic_picking</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.legend</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.line_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.scalar_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.bar.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.height</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.diffuse</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_camera_orientation_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.cap_opacity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Pen.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.add_key_event</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.view_zx</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.has_border</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor.name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Pen.width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.remove_chart</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.area.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.open_gif</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.generate_orbital_path</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.view_xz</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.view_xy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.title.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.font</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.point_size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_terrain_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.border_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.smooth_shading</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.roughness</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.y1.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.label_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.map_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.set_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.line_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.disable_depth_peeling</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.border_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.below_range_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Prop3D.scale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.active_background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.update_scalars</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.clear.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Axes.hide_actor</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.brush.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.remove_plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_bounding_box</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.y_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.remove_actor</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.z_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.reset_pickabilities</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_count.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Prop3D.position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.line_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Pen.style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.orientation</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.color_scheme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.show_axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.y_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.marker_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Axes.show_actor</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.loc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.z_axis_label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.values</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.colors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_on_render_callback</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_sphere_widgets</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.loc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Prop3D.user_matrix</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.border_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.specular</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.view_zy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.loc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.roughness</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.show.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_lines</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.border_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.center</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_mesh_picking</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.show.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.apply_cmap</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.border_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_rubber_band_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.enable_ssao</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.add_pick_observer</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.line_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.camera_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.legend_visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.slider_length</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.legend_visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.add_timer_event</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.hide_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.remove_bounds_axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.line_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.anisotropy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.set_viewup</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.line_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.ambient_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.jupyter_extension_available</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.border_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.terminate_app</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.ticks_visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.tip_length</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.loc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.disable_depth_of_field</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.line_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.add_legend</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.border_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.LookupTable.ramp</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.nan_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.active_border_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.sharp_edges_feature_angle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.pen.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.parallel_projection</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.specular_power</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.line_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_plane_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.colors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.allow_empty_mesh</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.pen.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.process_events</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Pen.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.parallel_projection</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.x_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.create_timer</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.stack.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.fly_to_mouse_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.remove_legend</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_zoom_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_axes_at_origin</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.x_axis_label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.redraw_on_render.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.get_pick_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.enable_hidden_line_removal</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.multi_rendering_splitting_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_checkbox_button_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_label_format</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderConfig.modern</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.background_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.background_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Brush.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.axes_enabled</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Brush.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CameraPosition.focal_point</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.border_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.show_bounds</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_clip_box</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_volume</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Brush.texture_interpolate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.view_xz</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Prop3D.rotate_x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.behavior.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.TextProperty.frame_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.image</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Actor.copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.enable_terrain_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.diffuse</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.clear_on_render_callbacks</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.AxesActor.z_axis_shaft_properties</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.colors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_text_slider_widget</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.active_background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.DataSetMapper.set_custom_opacity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.show.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.add_floor</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.brush.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.disable</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Brush.texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.box</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.camera</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_labels_offset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.set_picker</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.suppress_rendering</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.label_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.opacity_unit_distance</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Renderer.set_scale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.metallic</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_label_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.render_points_as_spheres</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.active_background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Property.specular</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_logo_widgets</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.Plotter.untrack_mouse_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.y_axis.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_spline_widgets</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.labels</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.background_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.orientation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_labels_visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.color_scheme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.line_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.pen</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.y2.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.stack</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.ys.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.border_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.brush.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.border_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.line_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Brush.texture</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.log_scale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.title.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.colors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.y_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.border_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.legend_visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.brush.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.active_background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.border_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.legend_visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.pen.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.y_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.log_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.label_visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.pen</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.background_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_label_size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.brush.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.brush</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.color_scheme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.border_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.active_background_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.brush.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.pen</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.border_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.background_texture</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_locations.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.x_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.background_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.scatter.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.y2</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.border_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.brush.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.color_scheme</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.legend_visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.loc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.scatter</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.pen.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.title.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.ys</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.show.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.border_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.toggle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.active_background_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.plots.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.plots</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.border_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.active_border_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.area</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.labels</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.data.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.behavior</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.title</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Pen.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Brush.texture_repeat.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.remove_plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.pen.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.x_axis.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.color_scheme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.color_scheme</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.scalar_map_mode.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.labels</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_logo_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_ssao.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.bar</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.interpolation_type.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.x_label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.diffuse_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.active_border_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_parallel_projection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.x_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_surface_point_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.title</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.reset_key_events.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.interpolate_before_map.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.label_size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.set_chart_interaction.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Brush.texture_interpolate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.update_bounds_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.active_border_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.actors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.line_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.line_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.y_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.pen</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.set_environment_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.colors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.remove_actor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.below_range_opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.above_range_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.brush</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_axis_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_lightkit.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.line_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.scalar_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.active_background_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.mouse_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_ssao.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._DepthPeelingConfig.number_of_peels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.values.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.line_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.hide_axes_all.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_fly_to_right_click.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.brush</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.sphere_radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.below_range_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.line_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_bounding_box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_depth_of_field.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.figure</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.hide_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.line_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.colorbar_vertical.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.show</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.isometric_view.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.marker_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_box_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Pen</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.background_texture</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.brush</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.add_timer_event.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.hide_axes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_terrain_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.orientation</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Timer.execute.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.y_label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.destroy_timer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_line_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.active_border_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.show_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.write_frame.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_labels</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_depth_peeling.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Brush</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.loc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_poked_renderer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.line</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.show_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.brush</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Brush.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.open_gif.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_count</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.justification_horizontal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.loc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.ambient.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.color_scheme</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.untrack_mouse_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Brush.texture_repeat</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._DepthPeelingConfig.occlusion_ratio.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.line_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.render_points_as_spheres.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.label_visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.labels</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._DepthPeelingConfig.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.border_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_title.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.line_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Axes.hide_symmetric.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.colorbar_orientation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.ticks_visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_axes_at_origin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.background_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_trackball_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_rectangle_visible_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.reset_camera_clipping_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.actors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.title</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_plane_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_desired_update_rate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.active_border_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.disable_depth_peeling.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.border_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_sphere_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.x_axis</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.use_2d_mode.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Axes.show_symmetric.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.line_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.scalar_map_mode.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._CameraConfig.position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.ramp.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.border_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_camera_orientation_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.redraw_on_render</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.scalar_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.active_background_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.pick_mouse_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.reset_colors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.y1</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.remove_all_lights.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.pen</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.export_gltf.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.label</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.update_bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.restore_defaults.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.y_axis</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.unlink_views.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.x_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.marker_size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.show_bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.line_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.isometric_view.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.show</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_clip_box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Pen.style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CameraPosition.viewup.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.clear.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.brush</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.legend_visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_blurring.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.legend.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.render_lines_as_tubes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.stats</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.add_observer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Pen.width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._CameraConfig.viewup.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_isovalue.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.background_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.border_style</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.remove_chart.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.scalar_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.colors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.sphere_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.set_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.loc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.set_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.enabled.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.deep_clean.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.colors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.show_axes_all.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.grid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.jupyter_extension_enabled.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.metallic.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_locations</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.slider_styles.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.show</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.update.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.show_scalar_bar.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.line_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.culling.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.grid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_box_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.legend_visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.log_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.get_pick_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.camera_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderConfig.modern.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.background_texture</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CornerAnnotation.linear_font_scale_factor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.ScatterPlot2D.line_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.BlockAttributes.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.title</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssemblySymmetric.y_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.Chart2D.clear</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CameraPosition.position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.tick_labels_offset</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_terrain_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.tube_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.background_texture</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.load_theme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.Axis.margin</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_stereo_render.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.brush</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.renderer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartPie.show</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.background_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_joystick_actor_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.StackPlot.pen</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.lighting.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.lighting_params.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.key_press_event.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BarPlot.y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.tip_type.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.BoxPlot.visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.multi_rendering_splitting_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.LinePlot2D.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_background_image.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartBox.border_width</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.close.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.ChartMPL.legend_visible</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_floor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.AreaPlot.toggle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.has_charts.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.color_scheme</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.shaft_type.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/_autosummary/pyvista.plotting.charts.PiePlot.pen</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_event_subplot_loc.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/pen_line_styles</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.remove_blurring.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/scatter_marker_styles</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.close.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/index</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.cmap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/charts/plot_color_schemes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.interpolate_before_map.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/qt_plotting</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.prop.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/theme</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.notebook.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/conv_func</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.tube_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/plotting</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_box_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/index</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_depth_of_field.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/plotting/trame</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.view_yx.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/enums</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.update_bounds_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.BaseReader.reader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_eye_dome_lighting.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.enable_point_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_shadows.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XMLPUnstructuredGridReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PNMReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.slider_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PVDReader.active_time_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.reset_opacities.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.DICOMReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.legend.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XdmfReader.number_grids</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.alpha_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.remove_all_functions</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.render_points_as_spheres.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.preserve_intermediate_functions</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.y_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PVDReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CameraPosition.focal_point.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.TimeReader.number_time_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.open_movie.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.DEMReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_image_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.patch_array_names</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.ambient_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PVDReader.datasets</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_measurement_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.unsteady_pattern</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.HDFReader.read</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.axes_enabled.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.number_family_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.update_scalar_bar_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.TIFFReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.enable_fly_to_right_click.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XMLRectilinearGridReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.set_active_time_point</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.disable_hidden_line_removal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.base_array_names</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.orientation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.SLCReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_text_slider_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.point_array_names</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.set_focus.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.BaseReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.EnSightReader.number_time_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.background_opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.distribute_blocks</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CornerAnnotation.get_text.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.BaseReader.read</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.jupyter_extension_available.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.disable_all_patch_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.resolve.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.EnSightReader.set_active_time_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.slider_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.family_array_status</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_camera_orientation_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XMLPolyDataReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_slice_spline.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PTSReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.enable_path_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.number_time_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_cell_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.enable_patch_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.above_range_opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XMLStructuredGridReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PNGReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_label_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.disable_all_bases</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_volume_clip_plane.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.disable_cell_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.center.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.skip_zero_time</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_element_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.number_patch_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.point_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.time_point_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.server_proxy_prefix.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.scalar_bar.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.GIFReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.picked_cells.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.number_point_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.get_default_cam_pos.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MetaImageReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_axes_at_origin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.TimeReader.time_values</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.VTKPDataSetReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.untrack_mouse_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.BaseReader.show_progress</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.window_size_context.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.all_cell_arrays_status</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_axis_minor_tick_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.FacetReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_measure_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.get_reader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.get_image_depth.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XMLMultiBlockDataReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.set_render_window.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_plane_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.vector_3d</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.HDFReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.diffuse.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.AVSucdReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.deep_clean.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.disable_all_cell_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.view_yz.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.Plot3DMetaReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.z_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XMLUnstructuredGridReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.edge_opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.disable_patch_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_silhouette.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.point_array_status</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_bounding_box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.enable_cell_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_spline_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.HDRReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_trackball_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PVDReader.active_datasets</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.label_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OBJReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.screenshot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.VTKDataSetReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_eye_dome_lighting.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.load_boundary_patch</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.track_mouse_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.BinaryMarchingCubesReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Axes.origin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.TimeReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.font_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.number_base_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_checkbox_button_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XdmfReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.z_axis_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.EnSightReader.set_active_time_point</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_light.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.set_active_time_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_zoom_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PVDReader.set_active_time_point</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.roughness.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XMLPRectilinearGridReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.get_default_cam_pos.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.cell_to_point_creation</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.camera.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.number_cell_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.border_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PVDReader.active_readers</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.family_array_names</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.silhouette.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.TecplotReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_custom_trackball_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.decompose_polyhedra</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.cell_array_names</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.on_plotter_render.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.add_q_files</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_depth_peeling.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.SegYReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_plane_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.TimeReader.set_active_time_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.n_values.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.active_time_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.POpenFOAMReader.case_type</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.remove_bounding_box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PVDReader.number_time_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.anti_aliasing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XdmfReader.set_active_time_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_arrows.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.disable_all_point_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.view_xy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.enable_all_point_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.border_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XMLImageDataReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.enable_all_families</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.XMLPImageDataReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.image_depth.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.FluentReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_logo_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PVDReader.time_values</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_sphere_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.BaseReader.path</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CornerAnnotation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.TimeReader.active_time_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_threshold.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.all_point_arrays_status</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.value_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.add_function</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.disable_parallel_projection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.patch_array_status</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.backface_prop.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.enable_all_cell_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_point_scalar_labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PLYReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_legend.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.TimeReader.set_active_time_point</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.reset_visibilities.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PVDReader.set_active_time_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume.Volume.prop.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.BMPReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.left_button_down.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.TimeReader.time_point_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.apply_lookup_table.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MFIXReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Text.position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.auto_detect_format</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.map_value.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.EnSightReader.time_point_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_axis_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.NIFTIReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.set_chart_interaction.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PVDReader.time_point_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.import_gltf.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.remove_function</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_timer_event.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.gamma</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.subplot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.all_patch_arrays_status</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.array_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.r_gas_constant</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_actor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.BaseReader.hide_progress</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_line_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.EnSightReader.active_time_value</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.origin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.base_array_status</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.rotate_z.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.disable_all_families</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.disable_eye_dome_lighting.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.NRRDReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.colorbar_horizontal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.BYUReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_legend.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.enable_all_patch_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.scalar_bars.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.cell_array_status</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.z_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.EnSightReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.POpenFOAMReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.get_block.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.GLTFReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_custom_trackball_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.disable_point_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_north_arrow_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.STLReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_ruler.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.JPEGReader</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.emissive.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/_autosummary/pyvista.CGNSReader.enable_all_bases</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/readers/index</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/objects</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.auto_close.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/helpers</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_axis_minor_tick_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.background.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/filters</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.z_axis_shaft_properties.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/lights</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.DarkTheme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.view_zy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.texture_map_to_plane</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.create_axes_orientation_box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.tube</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.label_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.copy_attributes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.lights.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.edges</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_camera3d_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.triangulate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.picked_actor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.bounds</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_clip_plane.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.remove_cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.family.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_surface</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.store_mouse_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.sample_over_multiple_lines</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.show_vertices.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_largest</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.z_axis_tip_properties.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.set_active_tensors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.scalar_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.flip_y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_camera3d_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.sample_over_line</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.export_vtksz.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.cell_data_to_point_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.get_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssemblySymmetric.labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.interpolate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.picked_cell.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.keys</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.specular.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.slice_implicit</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.layer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.dimensions</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.compute_cell_sizes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.image.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.remove_floors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.interactive_ratio.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_normals_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.lookup_table.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.ribbon</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.camera_set.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.surface_indices</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._DepthPeelingConfig.enabled.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.set_block_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.remove_observer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.elevation</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.background_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.save</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_environment_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.find_cells_within_bounds</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.add_pick_observer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.translate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_text.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.get_data_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.cap_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGrid.celltypes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_stereo_render.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.transform</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.cell_centers</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.view_zx.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.RectilinearGrid.points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.anisotropy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.n_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.italic.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.cell_coords</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.title_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.extract_all_edges</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.track_mouse_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_t_coords</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.total_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.RectilinearGrid.z</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.suppress_rendering.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.set_active_scalars</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.interpolation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.neighbors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_sphere_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.specular_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.enable.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.number_of_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.disable.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.copy_meta_from</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.BlockAttributes.visible.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.focal_point</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_logo_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_texture_coordinates_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_rubber_band_2d_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.cone_angle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.lighting.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_vectors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_threshold.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.combine</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.cone_radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.separate_cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.n_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.set_background.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.number_of_cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.view_xz.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_bounding_box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.split_bodies</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.view_vector.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.cell_neighbors_levels</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.transparent_background.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_tensors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.enable_shadow.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.reset_camera.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.RectilinearGrid.y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.reset_picker.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.is_all_polydata</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.user_matrix.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.n_blocks</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.slider_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters.median_smooth</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Text.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.slice</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CornerAnnotation.prop.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.from_paraview_pvcc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.cylinder_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.verts</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.picked_mesh.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_scalars</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.DocumentTheme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.cell_normals</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.increment_point_size_and_line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.clip_box</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_orientation_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_scalars_info</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_border.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.point_data_to_cell_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.clear_actors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.tight</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.roughness.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.area</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.point_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_composite.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.remove</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.remove_legend.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.find_cells_along_line</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.enable_anti_aliasing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.distance</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.n_ylabels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters.gaussian_smooth</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_line_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.partition</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.color_cycler.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.key_press_event.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.streamlines_evenly_spaced_2D</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.x_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters.extract_subset</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.last_update_time.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData.points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.generate_orbital_path.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.switch_on</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_chart.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.get_data_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_camera3d_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.find_cells_intersecting_line</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_clip_plane.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.extend</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._CameraConfig.parallel_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters.rfft</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.clear_key_event_callbacks.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_vectors_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plot_arrows.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.from_vtk</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.set_font_file.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.transform_matrix</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.export_obj.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.boolean_intersection</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_hidden_line_removal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.from_regular_faces</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.jupyter_server_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.threshold</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.BlockAttributes.opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.rotate_cw</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.cap_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGrid.cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.nan_opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.clip_box</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_slice.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.StructuredGrid.y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.shade.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.extrude</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._ColorbarConfig.width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.save</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.camera_set.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.set_scene_light</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.font.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.sort_labels</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.sharp_edges_feature_angle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.warp_by_vector</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.enable_depth_of_field.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.has_border.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.threshold_percent</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.show_labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.outline_corners</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.outline_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.get_index_by_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.array_name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.decimate_boundary</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.picker.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.is_scene_light</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_slider_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.point_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.set_background.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.copy_meta_from</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_trackball_actor_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.extrude_rotate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.title.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_button_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.track_click_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.view_angle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.x_axis_tip_properties.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.length</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.close.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.point_data_to_cell_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.allow_empty_mesh.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.world_position</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.show.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.cell_data_to_point_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderConfig.classic.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.RectilinearGrid.x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.remove_observers.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.collision</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.dataset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.StructuredGrid.hide_cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.memory_address.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.curvature</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.cylinder_radius.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.extrude_trim</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.process_events.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.dimensions</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.memory_address</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.parallel_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.arrows</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_all_lights.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.strip</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._ColorbarConfig.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.extract_surface</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_label_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.delaunay_2d</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.smooth_shading.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.add_field_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_actors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.cell_centers</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_camera_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.actual_memory_size</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_axis_minor_tick_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.clear</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.view_zy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGridFilters.reconstruct_surface</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.enable_ssao.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.slice_implicit</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssemblySymmetric.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.compute_connectivity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.center</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.x_axis_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.cast_to_unstructured_grid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.frame_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.StructuredGrid.z</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.opacity_unit_distance.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.smooth_taubin</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_2d_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.cast_to_unstructured_grid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_measurement_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_vectors_info</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.label_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.obbTree</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.find_closest_cell</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_key_event.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.find_cells_along_line</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.window_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.slice_along_axis</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.get_charts.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.clip_scalar</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_point_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.reset_clipping_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_text_slider_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.n_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_parallel_projection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.threshold_percent</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssemblySymmetric.x_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.face_normals</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.frame_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.decimate_boundary</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.shape.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.cell</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.opts.ElementType.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.update_scalars.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData.x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.label_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.tessellate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData.spacing</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_label_format.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.n_lines</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.orientation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.core.utilities.arrays.FieldAssociation</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.volume</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.where_is.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.contour_banded</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_light.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.subdivide_adaptive</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.meshes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.rename_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_bounds_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.center</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.parallel_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.to_image</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.return_cpos.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.hide_actor</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.still_ratio.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.to_grayscale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume.Volume.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.tessellate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.add_key_event.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.azimuth</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_events_for_key.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_texture_coordinates</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_rubber_band_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters.fft</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.image_scale_context.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGridFilters.subdivide_tetra</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.x_axis_shaft_properties.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.thickness</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.save.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.ray_trace</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.fly_to_mouse_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.attenuation_values</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.save_graphic.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_tensors_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters.high_pass</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.import_vrml.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.set_direction_angle</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.x_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.copy_from</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.jupyter_server_port.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.point_neighbors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_zoom_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.wrap</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.above_range_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.rotate_z</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._ColorbarConfig.height.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.positional</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_affine_transform_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.contour</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.ParaViewTheme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.cast_to_unstructured_grid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.terminate_app.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.plot_over_line</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.cmap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.compute_cell_sizes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.show_bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.merge</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.add_pick_obeserver.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.elevation</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.set_plot_theme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.get_edge</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_orientation_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.hide_cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Timer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.area</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_slider_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.geodesic</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.reset_camera.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.visible_bounds</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.below_range_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_all_edges</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.cmap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.set_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.label_offset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.renderers</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.view_xy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.threshold</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_feature_edges</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_ruler.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.volume</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.update_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.connectivity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_rubber_band_2d_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.is_all_triangles</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.rotate_x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.faces</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.color_missing_with_nan.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.streamlines</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_actor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.ctp</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.n_zlabels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGrid.offset</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.enable_parallel_projection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.point_normals</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.append_polydata</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.saturation_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.x_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.RectilinearGrid.dimensions</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_rectangle_through_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.is_camera_light</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Label.position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.clear_field_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_blurring.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.clipping_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.parallel_projection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.repeat</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.nan_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.pop</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.enable_camera_orientation_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.flip_y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CameraPosition.to_list.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.show_cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.decimate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData.cast_to_structured_grid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.set_color_cycler.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.get_data_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.rotate_y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.cube_map</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.isometric_view_interactive.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.lookup_table.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.world_focal_point</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.decimate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.track_click_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.show_actor</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.fly_to_mouse_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.specular_power.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.flip_normal</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.clip_closed_surface</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.create_axes_marker.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.center</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.render_lines_as_tubes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_normals</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.theme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.copy_structure</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderStyleConfig.cap_opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.get_data_range</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_trackball_actor_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.StructuredGrid.dimensions</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.rebuild.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.triangulate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_slider_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.point_ids</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_path_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.shallow_copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_axis_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_camera_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_scalars_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.server_proxy_enabled.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.set_headlight</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.opts.RepresentationType.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.import_3ds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters.low_pass</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.direction</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.shaft_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.n_faces</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_volume.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.shallow_copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.camera_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.ptc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_axis_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.probe</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.add_renderer</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_button_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.reflect</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_label_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.StructuredGrid.hide_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_rectangle_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.parallel_projection</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.before_close_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.slice_along_axis</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_slice.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.as_polydata_blocks</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.get_block_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.show_edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.valid_array_len</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.image_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.is_headlight</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.poked_subplot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.switch_off</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_joystick_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.StructuredGrid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.compute_normals</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_anti_aliasing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.integrate_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_scalar_bar.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.values</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.n_faces_strict</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.update_coordinates.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.head</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_background_image.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.edge_mask</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_joystick_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.field_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.viewport.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.set_vectors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.picked_point.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.plot_boundaries</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_title.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.texture_map_to_sphere</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_horizon_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData.z</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.name.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.set_environment_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.lines</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_logo_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.n_strips</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.enable_rubber_band_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.elevation</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.update</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.to_color_tf.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.pack_labels</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.height.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.to_pandas</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_slider_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.triangulate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_legend_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.n_edges</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.metallic.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.clean</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.show.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.array_names</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.clear_events_for_key.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGrid.cell_connectivity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.tick_location.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.is_linear</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.view_xz.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.items</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.disable_anti_aliasing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.light_type</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.fmt.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.copy_meta_from</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_geodesic_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData.origin</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_title.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.roll</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.rotate_vector</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.cone_resolution.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.RectilinearGrid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.pickable_actors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.flip_x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.get_pick_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.model_transform_matrix</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.edge_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.triangulate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.enable_eye_dome_lighting.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.subdivide</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.tip_length.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters.contour_labeled</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.bold.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.n_open_edges</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.create_timer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGrid.cast_to_explicit_structured_grid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.full_screen.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData.extent</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.font_family.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.cast_to_polydata</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.y_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.bounds</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.store_click_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.contour</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.initialize.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.get_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.view_zx.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.to_skybox</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_affine_transform_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.get</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_scalars_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_scalar_bar.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.pop</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.import_obj.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.outline</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.items</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_cursor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGrid.linear_copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_scalars</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_lines.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.get</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_chart.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_cells_by_type</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.edge_opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.align</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.annotations.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.find_closest_point</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.bounds.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.remove_bounds_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.extract_geometry</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_line_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.slice_orthogonal</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.disable_shadows.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.core.dataset.ActiveArrayInfo.copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.zoom</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_north_arrow_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.project_points_to_plane</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.mapper.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_normals</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.link_views.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData.to_tetrahedra</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.close.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.n_columns</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.set_color_cycler.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.StructuredGrid.points_matrix</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.show_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.keys</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.feature_angle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.point_cell_ids</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.show_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.compute_connections</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Text.input.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.glyph</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_on_render_callback.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.multi_ray_trace</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssemblySymmetric.z_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.plot_curvature</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.render_window.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.compute_arc_length</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.window_size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.clip_surface</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.faces</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.set_scalars.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.core.utilities.features.perlin_noise</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.reconstruct_surface</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.set_unique_colors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_texture_coordinates</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_image_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.point_neighbors_levels</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.title_offset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.flip_z</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.independent_components.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.delaunay_3d</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.ambient.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.dimension</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.hide_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.cast_to_polydata</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_clip_box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.is_set</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.default_mode.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.replace</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.diffuse.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.camera.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.mipmap</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.dataset.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.remove_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Axes.hide_actor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.to_paraview_pvcc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.enable.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.n_rows</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.trame.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.get</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_checkbox_button_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.append</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.floor_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.cell_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_floors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.merge</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._ColorbarConfig.position_y.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.get_array_association</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.specular_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.slice_along_axis</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.sample_over_circular_arc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.enable_shadows.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.rotate_ccw</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.n_components</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.logo_file.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.streamlines_from_source</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.disable.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.compute_implicit_distance</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_sphere_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.core.utilities.features.sample_function</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_axis_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.set_scalars</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_label_format.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.shrink</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_slice_orthogonal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.RectilinearGrid.meshgrid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.boolean_difference</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositePolyDataMapper.block_attr.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.scale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.set_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.up</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.reset_camera_clipping_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.interpolate</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Label.size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.extract_geometry</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.y_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.orientation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.bounds</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.n_faces</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.nan_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_geometry</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.user_matrix.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.plot_over_circular_arc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.enable_depth_peeling.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.flip_x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.line_width.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData.cast_to_rectilinear_grid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.specular.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.sample</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.box.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.focal_point</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.split_sharp_edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.plot_over_circular_arc_normal</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.clear_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_blurring.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.rotate_y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.color_mode.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.rotate_x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_2d_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.slice</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.AffineWidget3D.remove.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.n_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.explode</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.n_xlabels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.strips</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.interpolate_before_map.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.pop</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_legend_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.get_cell</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_chart.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.save</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.initialized.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.parallel_scale</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.specular_power.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.type</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_shadows.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.wrap_nested</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.parallel_projection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.outline_corners</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_spline_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.volume</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume.Volume.mapper.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.get_face</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.opts.InterpolationType.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.point_data_to_cell_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageData.y</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_slice_orthogonal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.insert</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.jupyter_backend.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.plot_normals</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.hue_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.shadow_attenuation</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.export_vrml.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.is_manifold</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.mapper._BaseMapper.scalar_range.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.cast_to_poly_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_joystick_actor_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.intensity</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CameraPosition.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.compute_derivative</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._AxesConfig.z_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.length</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_legend.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.untrack_click_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.flip_normals</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.BlockAttributes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.warp_by_scalar</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.apply_cmap.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.separate_cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.pickable.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGridFilters.delaunay_2d</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Axes.show_actor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.geodesic_distance</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.view_yz.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataObject.deep_copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.justification_vertical.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_vectors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._TrameConfig.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters.image_threshold</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.BlockAttributes.pickable.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.slice_along_line</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SilhouetteConfig.opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.on</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CompositeAttributes.reset_pickabilities.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Table.row_arrays</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.picked_block_index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.sample_over_circular_arc_normal</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.disable_depth_of_field.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.extract_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.point_is_inside_cell</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.click_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.select_enclosed_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.image_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.smooth</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.TextProperty.show_frame.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.exponent</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_interactor_style.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.slice_orthogonal</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.volume_mapper.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.disable_parallel_projection</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.next_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.find_containing_cell</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.view_isometric.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ExplicitStructuredGrid.cell_id</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.origin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.outline</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_anti_aliasing.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.clear_cell_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.plot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.view_frustum</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_mesh_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.clear_point_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_camera3d_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.shrink</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.show_edges.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.regular_faces</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.depth_peeling.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.volume</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_floor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.decimate_pro</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_spline_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.slice</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.enable_hidden_line_removal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.set_active_vectors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.volume_property.VolumeProperty.ambient.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.delaunay_3d</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._LightingConfig.diffuse.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.ImageDataFilters.image_dilate_erode</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CornerAnnotation.set_text.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGrid.cells_dict</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.label_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.StructuredGrid.x</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.set_scale.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.fill_holes</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesAssembly.z_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.point_is_inside_cell</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.enable_geodesic_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.view_vector.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.clip</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.camera.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.slice_along_line</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_point_labels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.save</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.y_axis_label.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.intersection</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.set_viewup.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.RectilinearGrid.cast_to_structured_grid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.get_event_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_t_coords</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.orbit_on_path.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.clip</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.hidden_line_removal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.values</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.y_axis_tip_properties.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.y_label_format.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGridFilters.clean</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._CameraConfig.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.slice_orthogonal</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.specular.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.explode</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.fly_to.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.ambient_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.remove_actor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_vectors_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.view_yx.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PointSet.cell_data_to_point_data</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._ColorbarConfig.position_x.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetFilters.compute_cell_quality</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.multi_samples.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Cell.plot</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.edge_color.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.core.dataset.ActiveArrayInfo</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.export_html.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGrid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.picking.PickingHelper.enable_horizon_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.n_cells</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.disable_ssao.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.active_t_coords_name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Actor.copy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.cell_neighbors</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_hidden_line_removal.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.diffuse_color</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Text.prop.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Texture.to_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.set_viewup.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.reverse</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Light.set_camera_light</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.apply_opacity.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.enable_parallel_projection</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_spline_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.Camera.copy</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_mesh_slice_spline.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.sample</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._Font.size.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.use_strict_n_faces</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.AxesActor.y_axis_shaft_properties.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.clean</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.view_isometric.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.MultiBlock.set_active_scalars</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes.Theme.interactive.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.cast_to_pointset</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.untrack_click_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyData.n_verts</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._SliderConfig.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSet.active_tensors_info</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_volume_clip_plane.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.UnstructuredGridFilters</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.start.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.DataSetAttributes.keys</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.CompositeFilters.slice_along_line</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_box_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/_autosummary/pyvista.PolyDataFilters.boolean_union</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.z_title.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/composite</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.camera.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/camera</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_block_picking.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/grids</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.RenderWindowInteractor.fly_to.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/misc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.disable_3_lights.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/dataset</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.enable_3_lights.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/pointsets</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/core/index</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.LookupTable.to_opacity_tf.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/geometric</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.add_mesh_isovalue.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/color_table/color_table</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.add_plane_widget.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricEnneper</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.specular_power.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.read_exodus</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.DataSetMapper.color_mode.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.float_rgb</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_measure_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.field_array</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Prop3D.origin.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.from_dict</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.zoom_camera.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.create_grid</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Property.interpolation.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.linear_to_srgb</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.widgets.WidgetHelper.clear_box_widgets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CylinderSource.height</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.set_focus.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.core.utilities.is_inside_bounds</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.add_box_axes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Icosphere</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.clear_on_render_callbacks.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricTorus</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.plotting.themes._CameraConfig.parallel_projection.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.MultipleLinesSource.output</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.render.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.vtk_points</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.pick_click_position.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Box</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.CubeAxesActor.x_axis_visibility.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.core.utilities.axis_rotation</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Renderer.remove_environment_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.name</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/index.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CircularArc</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset_gallery.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricCatalanMinimal</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gourds_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Polygon</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_electronics_cooling.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.transform_vectors_sph_to_cart</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_tetra_dc_mesh.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.grid_from_sph_coords</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_whole_body_ct_female.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.sample_function</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_pump_bracket.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ConeSource.output</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_mars_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.hex_rgb</loc>
-    <lastmod>2023-12-07T11:44:12+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_dicom_stack.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.SolidSphereGeneric</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_face.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.cubemap</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_crater_imagery.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricConicSpiral</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_room_surface_mesh.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Circle</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_vtk_logo.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricHenneberg</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_horse.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricRandomHills</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_whole_body_ct_male.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Tube</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_mount_damavand.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Sphere</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_guitar.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Octahedron</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_openfoam_tubes.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Cylinder</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_rectilinear_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ConeSource.center</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_earth.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricSuperToroid</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.file_from_files.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Text3D</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_dikhololo_night.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.int_rgb</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_face2.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Pyramid</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CylinderSource</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.demos.demos.plot_glyphs.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Rectangle</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_moon.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CircularArcFromNormal</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_st_helens.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Spline</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_model_with_variance.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Arrow</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_dragon.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.image_to_texture</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_owl.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Cube</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_lidar.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Triangle</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_spline.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.numpy_to_texture</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_disc_quads.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CylinderSource.output</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.HexagonalPrism.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Tetrahedron</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_parched_canal_4k.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricKlein</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_foot_bones.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Dodecahedron</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_reservoir.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Superquadric</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_woman.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.cell_array</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_saturn_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.save_meshio</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_puppy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Line</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_letter_a.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ConeSource.resolution</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_neptune.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Report</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_usa_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Icosahedron</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_office.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ConeSource.height</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_angular_sector.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.to_dict</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_saturn_rings.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_saddle_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricPluckerConoid</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.plot_cell.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.strip_hex_prefix</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_teapot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.parametric_keywords</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_hydrogen_orbital.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ColorLike</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_can_crushed_hdf.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.SolidSphere</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cow_head.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricCrossCap</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_shark.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.voxelize_volume</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Tetrahedron.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.fit_plane_to_points</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_3gqp.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Cone</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_particles_lethe.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CylinderSource.radius</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_beach.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.wrap</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_usa.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Disc</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_lobster.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricEllipsoid</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_caffeine.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Plane</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_knee_full.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CylinderSource.resolution</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_embryo.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricDini</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_motor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricBoy</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_frog_tissues.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricSuperEllipsoid</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_fea_bracket.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricBohemianDome</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_mug.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.lines_from_points</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bird.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricMobius</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Empty.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ConeSource.direction</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_rectilinear.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.MultipleLinesSource.points</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bird_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CellType</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_aero_bracket.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.core.utilities.set_error_output_file</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_venus_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.core.utilities.VtkErrorCatcher</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_pine_roots.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.hex_rgba</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_neptune_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricKuen</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_doorman.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Wavelet</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_tecplot_ascii.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.merge</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gourds_pnm.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.point_array</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_headsq.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.array_from_vtkmatrix</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_jupiter_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.PlatonicSolid</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_notch_stress.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ConeSource.angle</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_pluto.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricBour</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_prism.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.vector_poly_data</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cubemap_space_4k.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.compare_images</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_damavand_volcano.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ConeSource</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.demos.demos.plot_datasets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.read_texture</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_carotid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.spherical_to_cartesian</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_puppy_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.vtkmatrix_from_array</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_filled_contours.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.MultipleLinesSource</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_knee.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.convert_color_channel</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bunny.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.vtk_c3ub</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cgns_structured.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CylinderSource.capping</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bolt_nut.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.read</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_blood_vessels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CylinderSource.direction</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_nut.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.srgb_to_linear</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_random_hills.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.is_pyvista_dataset</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_tetrahedron.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ConeSource.capping</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Wedge.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.opacity</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_coil_magnetic_field.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.perlin_noise</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_structured_grid_two.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.voxelize</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cylinder_crossflow.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CylinderSource.center</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.demos.demos.plot_beam.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.CylinderStructured</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_stars_sky_background.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricFigure8Klein</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Quadrilateral.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricRoman</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_channels.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.convert_array</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_letter_k.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.float_rgba</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_prostate.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.cartesian_to_spherical</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.demos.demos.glyphs.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.pyvista_ndarray</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_sea_vase.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.MultipleLines</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.vrml.download_teapot.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.surface_from_para</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.cubemap_from_filenames</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cad_model.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ParametricPseudosphere</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cake_easy.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.start_xvfb</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_carburetor.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.Color.int_rgba</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_moon_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.ConeSource.radius</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_e07733s002i009.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/_autosummary/pyvista.get_array</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Triangle.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/utilities</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_venus.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/parametric</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_globe_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/colors</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_iron_protein.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/utilities/index</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_turbine_blade.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/api/index</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Line.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/_static/webpack-macros</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_can.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/search</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_topo_global.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/user-guide/simple</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_sky_box_cube_map.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/user-guide/optional_features</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_drill.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/user-guide/what-is-a-mesh</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.demos.demos.plot_wave.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/user-guide/data_model</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_pluto_surface.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/user-guide/vtk_to_pyvista</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_masonry_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/user-guide/jupyter/index</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_emoji_texture.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/user-guide/jupyter/trame</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_structured_grid.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/user-guide/themes</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_tensors.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/user-guide/index</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_sparse_points.html</loc>
   </url>
   <url>
-    <loc>https://docs.pyvista.orgversion/stable/index</loc>
-    <lastmod>2023-12-07T11:44:13+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_rgba_texture.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_stars_cloud_hyg.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_honolulu.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_mars.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_uranus.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cow.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_fea_hertzian_contact_cylinder.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_head_2.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Polygon.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_tetbeam.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_urn.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_action_figure.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_sphere_vectors.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.TriangleStrip.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_t3_grid_0.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Pyramid.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_wavy.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_uranus_surface.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Hexahedron.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_human.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_tri_quadratic_hexahedron.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gif_simple.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cloud_dark_matter_dense.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_m4_total_density.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bird_bath.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cavity.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.demos.demos.plot_ants_plane.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_mercury_surface.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.download_3ds.download_iflamigm.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_room_cff.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_unstructured_grid.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_faults.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_vtk.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.vrml.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_crater_topo.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_dual_sphere_animation.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_sphere.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_explicit_structured.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gpr_path.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_can_crushed_vtu.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_jupiter.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.PolyVertex.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_meshio_xdmf.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_milkyway_sky_background.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_exodus.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_frog_tissue.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_saturn.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Vertex.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_chest.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cad_model_case.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_antarctica_velocity.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_naca.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_hexbeam.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_osmnx_graph.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cubemap_park.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_trumpet.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_head.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gpr_data_array.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_single_sphere_animation.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_oblique_cone.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.vrml.download_sextant.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_backward_facing_step.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_uniform.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.demos.demos.orientation_plotter.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_logo.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_prostar.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_horse_points.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_sky_box_nz.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_delaunay_example.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_quadratic_pyramid.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_armadillo.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_blow.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_spider.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_pepper.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_nefertiti.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_sky_box_nz_texture.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_bunny_coarse.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_torso.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_brain.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.Voxel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_kitchen.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_thermal_probes.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_saturn_rings.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_mercury.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_file.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.delete_downloads.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_structured.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_globe.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cgns_multi.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.download_3ds.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cake_easy_texture.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gears.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.demos.demos.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_notch_displacement.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_moonlanding_image.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_emoji.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_victorian_goblet_face_illusion.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.load_sun.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cells_nd.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_lshape.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_coastlines.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_poly_line.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cloud_dark_matter.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_brain_atlas_with_sides.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_lucy.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_ant.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.planets.download_sun_surface.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_black_vase.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.PolyLine.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_topo_land.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.examples.load_airplane.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_louis_louvre.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_cubemap_space_16k.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_clown.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_dolfin.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_particles.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.demos.demos.orientation_cube.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_plastic_vase.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_frog.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_ivan_angel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.cells.PentagonalPrism.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/_autosummary/pyvista.examples.downloads.download_gourds.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/builtin_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/cubemap_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/imagedata_3d_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/multiblock_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/rectilineargrid_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/all_datasets_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/imagedata_2d_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/imagedata_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/structuredgrid_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/medical_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/pointset_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/multiblock_homo_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/polydata_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/misc_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/explicitstructuredgrid_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/downloads_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/multiblock_single_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/unstructuredgrid_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/texture_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/pointcloud_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/surfacemesh_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/examples/dataset-gallery/multiblock_hetero_carousel.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/enums.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.BaseReader.reader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.enable_point_array.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.HDRReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.enable_patch_array.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XMLStructuredGridReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.time_point_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.enable_cell_array.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XMLPImageDataReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.TimeReader.number_time_points.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.number_patch_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.add_function.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.enable_all_point_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.cell_to_point_creation.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XdmfReader.number_grids.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.enable_all_families.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.EnSightReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.load_boundary_patch.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XMLUnstructuredGridReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.SLCReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.BMPReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.VTKDataSetReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.active_time_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.ParticleReader.endian.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.DICOMReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.GaussianCubeReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.GaussianCubeReader.hb_scale.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.GambitReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.POpenFOAMReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.base_array_status.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XMLRectilinearGridReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.auto_detect_format.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XMLPartitionedDataSetReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.enable_all_cell_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.GLTFReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.family_array_names.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.TimeReader.set_active_time_point.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.TimeReader.time_values.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PVDReader.set_active_time_point.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.ParticleReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PVDReader.datasets.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.disable_all_families.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.BaseReader.path.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.set_active_time_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.DEMReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.NRRDReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PVDReader.active_time_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.EnSightReader.active_time_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.Plot3DMetaReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.BinaryMarchingCubesReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PVDReader.active_readers.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.skip_zero_time.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.patch_array_status.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.HDFReader.read.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.AVSucdReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XMLPUnstructuredGridReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.number_time_points.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.TecplotReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.disable_all_bases.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XdmfReader.set_active_time_point.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XMLPolyDataReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XMLPRectilinearGridReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.EnSightReader.number_time_points.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.all_patch_arrays_status.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.HDFReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.GIFReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PVDReader.number_time_points.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.distribute_blocks.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.r_gas_constant.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.point_array_status.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.EnSightReader.set_active_time_point.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PLYReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XdmfReader.active_time_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XMLMultiBlockDataReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.vector_3d.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.EnSightReader.time_point_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.all_cell_arrays_status.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.remove_function.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PVDReader.active_datasets.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.patch_array_names.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.number_cell_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.BaseReader.hide_progress.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.unsteady_pattern.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.GESignaReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.STLReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XdmfReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.all_point_arrays_status.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.TIFFReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.number_base_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.FluentReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.number_point_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PVDReader.time_point_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.gamma.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.disable_all_point_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.enable_all_bases.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MINCImageReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.FLUENTCFFReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OBJReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.disable_all_patch_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.decompose_polyhedra.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.disable_all_cell_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.BaseReader.show_progress.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.NIFTIReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PVDReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.TimeReader.time_point_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.get_reader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PVDReader.set_active_time_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.TimeReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.EnSightReader.set_active_time_set.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.point_array_names.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.BaseReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.TimeReader.set_active_time_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.add_q_files.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PNGReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.BaseReader.read.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.base_array_names.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.disable_point_array.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.cell_array_status.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.BYUReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.disable_cell_array.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.set_active_time_point.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.enable_all_patch_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PNMReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.POpenFOAMReader.case_type.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.VTKPDataSetReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XdmfReader.set_active_time_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MetaImageReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.number_family_arrays.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XMLImageDataReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.GaussianCubeReader.b_scale.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PointCellDataSelection.cell_array_names.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.remove_all_functions.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PDBReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.EnSightReader.active_time_set.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XdmfReader.number_time_points.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PTSReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.EnSightReader.set_active_time_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.JPEGReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XdmfReader.time_point_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.OpenFOAMReader.disable_patch_array.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.FacetReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.ProStarReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.CGNSReader.family_array_status.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.SegYReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.TimeReader.active_time_value.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.PVDReader.time_values.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MFIXReader.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.XdmfReader.time_values.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.GaussianCubeReader.read.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/api/readers/_autosummary/pyvista.MultiBlockPlot3DReader.preserve_intermediate_functions.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/extras/building_vtk.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/extras/index.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/extras/plot_directive.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/extras/vtk_data.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/extras/pyinstaller.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/extras/docker.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/extras/developer_notes.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/extras/pytest_plugin.html</loc>
+  </url>
+  <url>
+    <loc>https://docs.pyvista.org/version/stable/extras/extending_pyvista.html</loc>
   </url>
 </urlset>


### PR DESCRIPTION
I manually published the 0.44 docs. These changes let our main site pick up on the new version

related https://github.com/pyvista/pyvista/pull/5360