### PR TITLE
Add stable site config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
 from = "/version/stable/*"
-to = "https://pyvista-0-44.netlify.app/:splat"
+to = "https://pyvista-stable.netlify.app/:splat"
 status = 200
 force = true
 

--- a/version/stable/netlify.toml
+++ b/version/stable/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+from = "*"
+to = "https://pyvista-0-44.netlify.app/:splat"
+status = 200
+force = true


### PR DESCRIPTION
This sets up a `pyvista-stable` site that will simply point to the latest version. On releases, this reference will need to be updated